### PR TITLE
[WIP] Naive request body parsing

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,0 +1,5 @@
+export const mimes = {
+  TEXT: 'text/plain',
+  JSON: 'application/json',
+  HTML: 'text/html',
+};

--- a/packages/core/src/parsers/request.ts
+++ b/packages/core/src/parsers/request.ts
@@ -1,0 +1,30 @@
+import { IncomingMessage } from 'http';
+import { mimes } from '../constants';
+
+const handleChunks = (contentType: string, chunks: string) => {
+  switch (contentType) {
+    case mimes.JSON:
+      return JSON.parse(chunks);
+    default:
+      return chunks;
+  }
+};
+
+const requestParser = (req: IncomingMessage) => {
+  return new Promise(resolve => {
+    const { method, headers } = req;
+    if (!method || !(method.toLowerCase() in ['post', 'put', 'patch'])) {
+      resolve({});
+      return;
+    }
+    let chunks = '';
+    req.on('data', chunk => {
+      chunks += chunk.toString();
+    });
+    req.on('end', () => {
+      resolve(handleChunks(headers['content-type'] || '', chunks));
+    });
+  });
+};
+
+export default requestParser;

--- a/packages/core/src/parsers/response.ts
+++ b/packages/core/src/parsers/response.ts
@@ -1,0 +1,26 @@
+import { mimes } from '../constants';
+
+const guessMime = (body: any) => {
+  if (Array.isArray(body) || typeof body === 'object') {
+    return mimes.JSON;
+  }
+  return mimes.TEXT;
+};
+
+const json = (body: any) => Buffer.from(JSON.stringify(body));
+const text = (body: any) => Buffer.from(body);
+
+const responseParser = (contentType: string, body: any) => {
+  const mime = contentType || guessMime(body);
+  switch (mime) {
+    case mimes.JSON:
+      return json(body);
+    case mimes.TEXT:
+    case mimes.HTML:
+      return text(body);
+    default:
+      return body;
+  }
+};
+
+export default responseParser;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,4 +22,5 @@ export interface Conn<T = any> {
     [key: string]: string;
   };
   halt: boolean;
+  request: any;
 }


### PR DESCRIPTION
- Places incoming request body into `conn.request` property
- Only handles incoming JSON
- Does no error checking on JSON parse failure
- Needs tests
- Added response guessing as well based on `conn.body`