### PR TITLE
Refactor groups to not need spread. Adds base function

### DIFF
--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -18,7 +18,11 @@ $ npm install -S @jaris/core @jaris/router
 import server, { text } from '@jaris/core';
 import router, { get } from '@jaris/router';
 
-server([router([get('/', conn => text('Hello, world!', conn))])]);
+server([
+  router([
+    get('/', conn => text('Hello, world!', conn))
+  ])
+]);
 ```
 
 ## Multi file structure
@@ -43,7 +47,9 @@ export default userController;
 import { get } from '@jaris/router';
 import userController from './user.controller';
 
-const apiRoutes = [get('/users', userController.index)];
+const apiRoutes = [
+  get('/users', userController.index)
+];
 
 export default apiRoutes;
 ```
@@ -55,7 +61,7 @@ import router from '@jaris/router';
 import apiRoutes from './api.routes.ts';
 
 server([
-  (conn) => {
+  conn => {
     console.log('Since the router is also just a middleware itself, we can have as many middleware before or after that we want!');
     return conn;
   }
@@ -92,7 +98,7 @@ import router, { get, post, group } from '@jaris/router';
 // so they need to follow the same rule
 // of returning a new connection
 const companyMiddleware = conn => {
-  const token = conn.headers['Authorization'];
+  const token = conn.headers.Authorization;
 
   // ... parse token
   // fetch user it belongs to
@@ -114,9 +120,7 @@ const companyMiddleware = conn => {
 
 server([
   router([
-    // groups need to be spread since
-    // they return an array of routes
-    ...group({ prefix: 'v1' }, () => [
+    group({ prefix: 'v1' }, [
       // will evaluate to /v1/users
       get('/users', userController.index),
 
@@ -124,13 +128,13 @@ server([
       post('users', userController.store),
 
       // groups can be nested
-      ...group(
+      group(
         {
           prefix: '/companies/:companyId',
           middleware: [companyMiddleware],
         },
-        () => [
-          // /v1/companies/:companyUid
+        [
+          // /v1/companies/:companyId
           get('/', companyController.show),
         ],
       ),

--- a/packages/router/src/base.ts
+++ b/packages/router/src/base.ts
@@ -1,4 +1,4 @@
-import { reduceP, pipe, trim } from '@jaris/util';
+import { reduceP, pipe, trim, flatten } from '@jaris/util';
 import { Route } from './types';
 import { IncomingMessage, ServerResponse } from 'http';
 import { Conn } from '@jaris/core';
@@ -110,7 +110,8 @@ export interface Router<T> {
 }
 
 export const baseRouter = (handler: Router<Conn>) => {
-  return (routes: Route[]) => {
+  return (routes: Array<Route | Route[]>) => {
+    const routesFlattened = flatten(routes) as Route[];
     return async (conn: Conn) => {
       const currentPath = handler.req(conn).url;
 
@@ -120,7 +121,7 @@ export const baseRouter = (handler: Router<Conn>) => {
 
       const [pathWithoutQuery, queryString] = currentPath.split('?');
 
-      const route = routes.find(
+      const route = routesFlattened.find(
         r =>
           toLower(r.verb) === toLower(handler.req(conn).method) &&
           matchPattern(pathWithoutQuery, r.path),

--- a/packages/router/src/builder.ts
+++ b/packages/router/src/builder.ts
@@ -1,11 +1,5 @@
 import { flatten, trim } from '@jaris/util';
-import {
-  Route,
-  GroupOptions,
-  HTTPVerb,
-  GroupCallback,
-  HandlerType,
-} from './types';
+import { Route, GroupOptions, HTTPVerb, HandlerType } from './types';
 
 const applyPrefix = (route: Route, prefix: string = '') => {
   const { path } = route;
@@ -61,13 +55,16 @@ export const destroy = (path: string, handler: HandlerType) => {
   return buildRouteObject('delete', path, handler);
 };
 
-export const group = (options: GroupOptions, callback: GroupCallback) => {
-  const updatedRoutes = callback().map(
+export const group = (
+  options: GroupOptions,
+  routes: Array<Route | Route[]>,
+) => {
+  const updatedRoutes = routes.map(
     (routeObj): Route | Route[] => {
       // handle nested group
 
       if (Array.isArray(routeObj)) {
-        return group(options, () => routeObj);
+        return group(options, routeObj);
       }
 
       let updatedRoute = { ...routeObj };
@@ -87,5 +84,9 @@ export const group = (options: GroupOptions, callback: GroupCallback) => {
     },
   );
 
-  return [...flatten(updatedRoutes)] as Route[];
+  return flatten(updatedRoutes) as Route[];
+};
+
+export const base = (routes: Array<Route | Route[]>): Route[] => {
+  return flatten(routes) as Route[];
 };

--- a/packages/router/src/builder.ts
+++ b/packages/router/src/builder.ts
@@ -1,5 +1,11 @@
 import { flatten, trim } from '@jaris/util';
-import { Route, GroupOptions, HTTPVerb, HandlerType } from './types';
+import {
+  Route,
+  GroupOptions,
+  HTTPVerb,
+  HandlerType,
+  GroupCallback,
+} from './types';
 
 const applyPrefix = (route: Route, prefix: string = '') => {
   const { path } = route;
@@ -57,9 +63,10 @@ export const destroy = (path: string, handler: HandlerType) => {
 
 export const group = (
   options: GroupOptions,
-  routes: Array<Route | Route[]>,
+  routes: Array<Route | Route[]> | GroupCallback,
 ) => {
-  const updatedRoutes = routes.map(
+  const resolvedRoutes = Array.isArray(routes) ? routes : routes();
+  const updatedRoutes = resolvedRoutes.map(
     (routeObj): Route | Route[] => {
       // handle nested group
 

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -22,4 +22,4 @@ export interface GroupOptions {
 
 export type ArrayItem = (routes: RoutesList) => RoutesList;
 
-export type GroupCallback = () => Route[];
+export type GroupCallback = () => Array<Route | Route[]>;

--- a/packages/util/__tests__/index.spec.ts
+++ b/packages/util/__tests__/index.spec.ts
@@ -1,0 +1,35 @@
+import { flatten } from '../lib';
+
+describe('util', () => {
+  describe('flatten', () => {
+    it('should not modify flat array', () => {
+      expect(flatten([1, 2, 3])).toEqual([1, 2, 3]);
+    });
+    it('should flatten 2d array', () => {
+      expect(flatten([[1, 2, 3], [4, 5, 6], [7, 8, 9]])).toEqual([
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+      ]);
+    });
+    it('should flatten 4d array', () => {
+      expect(flatten([[[[1, 2, 3]]], [4, [5], 6], [7, 8, 9]])).toEqual([
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+      ]);
+    });
+  });
+});

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -13,11 +13,11 @@ export const reduceP = async <T, S>(
   return cur;
 };
 
-export const flatten = <T>(arr: T[]) => {
+export const flatten = <T>(arr: T[]): T[] => {
   return arr.reduce(
     (carry, nextArr) => [
       ...carry,
-      ...(Array.isArray(nextArr) ? nextArr : [nextArr]),
+      ...(Array.isArray(nextArr) ? flatten(nextArr) : [nextArr]),
     ],
     [],
   );


### PR DESCRIPTION
Fixes #16 

- Removes need to spread routes (router does it by default now, or you can use `base` helper exported from router)
- `group` now can take just an array as the second arg instead of a callback (backwards compat)

before:
```javascript
const routes = [
  ...group({}, () => [
    get('/', conn => conn) 
  ])
]
```

after:
```javascript
const routes = [
  group({}, [
    get("/", conn => conn)
  ])
];
```