### PR TITLE
Extract createCallback into own func for servless possibilities

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,13 +4,13 @@
 
 Jaris. A 0 dependency, functional (phoenix) inspired, node / typescript web framework.
 
-# Installation
+## Installation
 
 ```
 $ npm install -S @jaris/core
 ```
 
-# Usage
+## Usage
 
 The core concept behind `jaris` is that the `conn` object gets passed through a series of functions (middleware), and the final resulting `conn` determines what is sent.
 
@@ -101,5 +101,17 @@ server([
       header('X-Total-Time', `${endTime - startTime} seconds`)
     )(conn);
   }
+]);
+```
+
+## Cloud Functions (Serverless)
+
+Jaris can also be used in a "serverless" environment (AWS Lambda, zeit, Google Cloud Functions) using the exported `lambda` function.
+
+```javascript
+const { lambda, json } = require('@jaris/core');
+
+module.exports = lambda([
+  conn => json({ ok: true })(conn),
 ]);
 ```


### PR DESCRIPTION
Closes #27 

Extracts callback for `http.createServer` so that we can use it to handle serverless funcs

e.g

```javascript
const { lambda, json } = require('@jaris/core')

module.exports = lambda([
  conn => json({ ok: true })(conn)
])
```

`lambda` is just an alias for `createCallback` which you could also import

```javascript
const { createCallback } = require('@jaris/core')
```